### PR TITLE
Run CI on merge into Main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,10 @@
 name: CI
-# Run on master, tags, or any pull request
+# Run on main, tags, or any pull request
 on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
 jobs:


### PR DESCRIPTION
The reason CI wasn't running on merging a  pull-request is that the docs were coded to master, but we have a default branch called main.
(this was to get ahead of the game, and because the default branch on gitlab before we open-sourced was master so it seems like it would simplify if we used a different name)