### PR TITLE
Use Interval Min/Max function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-Intervals = "1.3"
+Intervals = "1.5"
 julia = "1.3"
 
 [extras]

--- a/src/common.jl
+++ b/src/common.jl
@@ -41,17 +41,10 @@ Helper function to turn an AbstractInterval into a StepRange taking the inclusiv
 account.
 """
 function _interval2daterange(dates::AbstractInterval{Date})
-    fd = _firstdate(dates)
-    ld =_lastdate(dates)
+    fd = minimum(dates, increment=Day(1))
+    ld = maximum(dates, increment=Day(1))
     return fd:Day(1):ld
 end
-
-# TODO: remove this once https://github.com/invenia/Intervals.jl/issues/137
-# is addressed.
-_firstdate(dates::AbstractInterval{Date,Closed}) = first(dates)
-_firstdate(dates::AbstractInterval{Date,Open}) = first(dates) + Day(1)
-_lastdate(dates::AbstractInterval{Date,<:Bound,Closed}) = last(dates)
-_lastdate(dates::AbstractInterval{Date,<:Bound,Open}) = last(dates) - Day(1)
 
 """
     _initial_date(s::S, dates) where S<: DateSelector


### PR DESCRIPTION
Removes the internal _firstdate and _lastdate functions and uses the Interval minimum and maximum functions.

closes #2 