### PR TITLE
Fix CI Tests and Artifact Cache Issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,9 +23,9 @@ jobs:
         arch:
           - x64
         include:
-          # Add a 1.3 job because that's what Invenia actually uses
+          # Add a 1.5 job because that's what Invenia actually uses
           - os: ubuntu-latest
-            version: 1.3
+            version: 1.5
             arch: x64
           # Add a 32-bit job to ensure we don't have any 64-bit specific logic
           - os: ubuntu-latest
@@ -37,15 +37,16 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.arch }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -13,16 +13,14 @@ jobs:
         with:
           version: nightly
           arch: x64
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
-          cache-name: cache-artifacts
+          cache-name: julianightly-cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+            ${{ env.cache-name }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
Use CLI script to automatically replace the 1.3 test with a 1.5 test (if necessary), as well as use new cache steps to cache the julia build artifacts