### PR TITLE
Bump patch version for new docs/CI changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DateSelectors"
 uuid = "c900ad91-5c7c-41b8-bce1-46b0264fae1d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
The Julia compat was changed to 1.3 as well but I think since we're <1.0 on the package version this should be fine. 