### PR TITLE
Allow passing vectors of dates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DateSelectors"
 uuid = "c900ad91-5c7c-41b8-bce1-46b0264fae1d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/NoneSelector.jl
+++ b/src/NoneSelector.jl
@@ -5,4 +5,11 @@ Assign all dates to the validation set, select no holdout dates.
 """
 struct NoneSelector <: DateSelector end
 
-Iterators.partition(dates::StepRange{Date, Day}, ::NoneSelector) = _getdatesets(dates, Date[])
+function Iterators.partition(dates::AbstractVector{Date}, ::NoneSelector)
+    # Just to maintain consistency between selectors
+    if dates isa StepRange && step(dates) != Day(1)
+        throw(ArgumentError("Expected step range over days, not ($(step(dates)))."))
+    end
+
+    return _getdatesets(dates, Date[])
+end

--- a/src/PeriodicSelector.jl
+++ b/src/PeriodicSelector.jl
@@ -32,8 +32,11 @@ struct PeriodicSelector <: DateSelector
     end
 end
 
+function Iterators.partition(dates::AbstractVector{Date}, s::PeriodicSelector)
+    if dates isa StepRange && step(dates) != Day(1)
+        throw(ArgumentError("Expected step range over days, not ($(step(dates)))."))
+    end
 
-function Iterators.partition(dates::StepRange{Date, Day}, s::PeriodicSelector)
     initial_time = _initial_date(s, dates)
     sd, ed = extrema(dates)
 
@@ -43,7 +46,7 @@ function Iterators.partition(dates::StepRange{Date, Day}, s::PeriodicSelector)
     # is still is well under 1/4 second. so keeping it simple
 
     holdout_dates = Date[]
-    curr_window = initial_time:step(dates):(initial_time + s.stride - step(dates))
+    curr_window = initial_time:Day(1):(initial_time + s.stride - Day(1))
     while first(curr_window) <= ed
         # optimization: only creating holdout window if intersect not empty
         if last(curr_window) >= sd

--- a/src/RandomSelector.jl
+++ b/src/RandomSelector.jl
@@ -33,14 +33,18 @@ struct RandomSelector <: DateSelector
     end
 end
 
-function Iterators.partition(dates::StepRange{Date, Day}, s::RandomSelector)
+function Iterators.partition(dates::AbstractVector{Date}, s::RandomSelector)
+    if dates isa StepRange && step(dates) != Day(1)
+        throw(ArgumentError("Expected step range over days, not ($(step(dates)))."))
+    end
+
     sd, ed = extrema(dates)
 
     rng = MersenneTwister(s.seed)
 
     holdout_dates = Date[]
     initial_time = _initial_date(s, dates)
-    curr_window = initial_time:step(dates):(initial_time + s.block_size - step(dates))
+    curr_window = initial_time:Day(1):(initial_time + s.block_size - Day(1))
     while first(curr_window) <= ed
         # Important: we must generate a random number for every block even before the start
         # so that the `rng` state is updated constistently no matter when the start is

--- a/src/common.jl
+++ b/src/common.jl
@@ -10,6 +10,7 @@ abstract type DateSelector end
 """
     partition(dates::AbstractInterval{Date}, s::DateSelector)
     partition(dates::StepRange{Date, Day}, selector::DateSelector)
+    partition(dates::AbstractVector{Date}, s::DateSelector)
 
 Partition the set of `dates` into disjoint `validation` and `holdout` sets according to the
 `selector` and return a `NamedTuple({:validation, :holdout})` of iterators.

--- a/test/NoneSelector.jl
+++ b/test/NoneSelector.jl
@@ -9,4 +9,7 @@
     validation, holdout = partition(date_range, selector)
     @test validation == date_range
     @test isempty(holdout)
+
+    # Test that we can also handle any abstract vector
+    @test_throws MethodError partition(collect(date_range), selector)
 end

--- a/test/NoneSelector.jl
+++ b/test/NoneSelector.jl
@@ -11,5 +11,5 @@
     @test isempty(holdout)
 
     # Test that we can also handle any abstract vector
-    @test_throws MethodError partition(collect(date_range), selector)
+    @test first(partition(collect(date_range), selector)) == validation
 end

--- a/test/PeriodicSelector.jl
+++ b/test/PeriodicSelector.jl
@@ -13,6 +13,9 @@
         @test isempty(intersect(result...))
 
         @test all(isequal(Week(1)), diff(result.holdout))
+
+        # Test that we can also handle any abstract vector
+        @test_throws MethodError partition(collect(date_range), selector)
     end
 
     @testset "2 week period, 5 day stride" begin

--- a/test/PeriodicSelector.jl
+++ b/test/PeriodicSelector.jl
@@ -15,7 +15,7 @@
         @test all(isequal(Week(1)), diff(result.holdout))
 
         # Test that we can also handle any abstract vector
-        @test_throws MethodError partition(collect(date_range), selector)
+        @test partition(collect(date_range), selector) == result
     end
 
     @testset "2 week period, 5 day stride" begin

--- a/test/RandomSelector.jl
+++ b/test/RandomSelector.jl
@@ -46,7 +46,7 @@
         @test result.holdout == result2.holdout
 
         # Test that we can also handle any abstract vector
-        @test_throws MethodError partition(collect(date_range), selector)
+        @test partition(collect(date_range), selector) == result
 
         @testset "holdout fraction" begin
             # Setting holdout_fraction 1 all days leaves the validation set empty

--- a/test/RandomSelector.jl
+++ b/test/RandomSelector.jl
@@ -45,6 +45,9 @@
         @test result.validation == result2.validation
         @test result.holdout == result2.holdout
 
+        # Test that we can also handle any abstract vector
+        @test_throws MethodError partition(collect(date_range), selector)
+
         @testset "holdout fraction" begin
             # Setting holdout_fraction 1 all days leaves the validation set empty
             validation, holdout = partition(date_range, RandomSelector(42, 1))

--- a/test/sensibility_checks.jl
+++ b/test/sensibility_checks.jl
@@ -31,9 +31,9 @@
         end
     end
 
-    @testset "Vector of days is not allowed" begin
+    @testset "Vector of days is allowed" begin
         date_range = collect(Date(2019, 1, 1):Day(1):Date(2019, 2, 1))
-        @test_throws MethodError partition(date_range, NoneSelector())
+        @test first(partition(date_range, NoneSelector())) == date_range
     end
 
     @testset "Weekly intervals are not allowed" begin
@@ -46,7 +46,7 @@
             PeriodicSelector(Week(2), Week(1)),
             RandomSelector(42),
         )
-            @test_throws MethodError partition(weekly_dates, selector)
+            @test_throws ArgumentError partition(weekly_dates, selector)
         end
     end
 end


### PR DESCRIPTION
This should be non-breaking as we're just loosening some of the existing restrictions. Most of the code already worked for abstract vectors, but now we hard code `step(dates)` as `Day(1)` and throw an `ArgumentError` if we're passed a different step size. Needed to update a single pre-existing test which didn't allow vectors and switched the step size tests to check the `ArgumentError` vs `MethodError`.

Closes #18 

Also may satisfy the requirements for #14 and #17. Although, maybe having a separate PR for an `ExcludeSelector` would be useful?